### PR TITLE
크로스 플랫폼 호환성을 위한 Python 실행 파일 경로 업데이트

### DIFF
--- a/case1/auto_mcp_json.py
+++ b/case1/auto_mcp_json.py
@@ -48,7 +48,10 @@ def create_mcp_json():
     project_root = Path(__file__).parent.absolute()
 
     # .venv python executable path
-    python_path = str(project_root.parent / ".venv" / "bin" / "python")
+    if os.name == 'nt':  # Windows
+        python_path = str(project_root.parent / ".venv" / "Scripts" / "python.exe")
+    else:  # Mac, Ubuntu etc
+        python_path = str(project_root.parent / ".venv" / "bin" / "python")
 
     server_script = project_root / "mcp_server.py"
 

--- a/case2/auto_mcp_json.py
+++ b/case2/auto_mcp_json.py
@@ -29,7 +29,10 @@ def create_mcp_json():
     project_root = Path(__file__).parent.absolute()
 
     # .venv python executable path
-    python_path = str(project_root.parent / ".venv" / "bin" / "python")
+    if os.name == 'nt':  # Windows
+        python_path = str(project_root.parent / ".venv" / "Scripts" / "python.exe")
+    else:  # Mac, Ubuntu etc
+        python_path = str(project_root.parent / ".venv" / "bin" / "python")
 
     server_script = project_root / "mcp_server.py"
 

--- a/case3/auto_mcp_json.py
+++ b/case3/auto_mcp_json.py
@@ -29,7 +29,10 @@ def create_mcp_json():
     project_root = Path(__file__).parent.absolute()
 
     # .venv python executable path
-    python_path = str(project_root.parent / ".venv" / "bin" / "python")
+    if os.name == 'nt':  # Windows
+        python_path = str(project_root.parent / ".venv" / "Scripts" / "python.exe")
+    else:  # Mac, Ubuntu etc
+        python_path = str(project_root.parent / ".venv" / "bin" / "python")
 
     server_script = project_root / "mcp_server.py"
 

--- a/case4/auto_mcp_json.py
+++ b/case4/auto_mcp_json.py
@@ -31,7 +31,10 @@ def create_mcp_json():
     project_root = Path(__file__).parent.absolute()
 
     # .venv python executable path
-    python_path = str(project_root.parent / ".venv" / "bin" / "python")
+    if os.name == 'nt':  # Windows
+        python_path = str(project_root.parent / ".venv" / "Scripts" / "python.exe")
+    else:  # Mac, Ubuntu etc
+        python_path = str(project_root.parent / ".venv" / "bin" / "python")
 
     server_script = project_root / "mcp_server.py"
 


### PR DESCRIPTION
- 운영 체제가 Windows인지 확인하기 위해 os.name에 대한 조건부 검사를 추가했습니다.
- Windows에서는 Scripts/python.exe를 사용하고, Mac 및 Ubuntu와 같은 다른 시스템에서는 bin/python을 사용하도록 Python 실행 파일 경로를 업데이트했습니다.